### PR TITLE
Update cli debug log toggle

### DIFF
--- a/packages/@runlightyear/cli/src/commands/dev/index.ts
+++ b/packages/@runlightyear/cli/src/commands/dev/index.ts
@@ -4,7 +4,10 @@ import getPusherCredentials from "../../shared/getPusherCredentials";
 import handleRunLocal from "./handleRunLocal";
 import nodemon from "nodemon";
 import { terminal } from "terminal-kit";
-import { setLogDisplayLevel, logDisplayLevel } from "../../shared/setLogDisplayLevel";
+import {
+  setLogDisplayLevel,
+  logDisplayLevel,
+} from "../../shared/setLogDisplayLevel";
 import { prepareConsole } from "../../logging";
 import handleResubscribe from "./handleResubscribe";
 import { largeLogo } from "../../largeLogo";
@@ -19,7 +22,7 @@ export const dev = new Command("dev");
 
 dev
   .description(
-    "Automatically deploy changes, run actions, and respond to webhooks in your dev environment"
+    "Automatically deploy changes, run actions, and respond to webhooks in your dev environment",
   )
   .addOption(new Option("--dev").hideHelp())
   .action(async () => {
@@ -37,10 +40,10 @@ dev
     const pusher = await getPusher(credentials);
 
     console.debug(
-      `Attempting to subscribe to presence channel ${credentials.devEnvId}\n`
+      `Attempting to subscribe to presence channel ${credentials.devEnvId}\n`,
     );
     const presenceSubscription = pusher.subscribe(
-      `presence-${credentials.devEnvId}`
+      `presence-${credentials.devEnvId}`,
     );
     presenceSubscription.bind("pusher:subscription_succeeded", () => {
       console.debug("Subscribed to presence channel\n");
@@ -48,7 +51,7 @@ dev
 
     console.debug(
       "Attempting to subscribe to regular channel",
-      credentials.devEnvId
+      credentials.devEnvId,
     );
     const subscription = pusher.subscribe(credentials.devEnvId);
     subscription.bind("pusher:subscription_succeeded", () => {
@@ -59,23 +62,23 @@ dev
     subscription.bind("localResubscribeTriggered", handleResubscribe);
     subscription.bind(
       "localGetAuthRequestUrlTriggered",
-      handleGetAuthRequestUrl
+      handleGetAuthRequestUrl,
     );
     subscription.bind(
       "localRequestAccessTokenTriggered",
-      handleRequestAccessToken
+      handleRequestAccessToken,
     );
     subscription.bind(
       "localRefreshAccessTokenTriggered",
-      handleRefreshAccessToken
+      handleRefreshAccessToken,
     );
     subscription.bind(
       "localRefreshSubscriptionTriggered",
-      handleRefreshSubscription
+      handleRefreshSubscription,
     );
     subscription.bind(
       "localReceiveCustomAppWebhookTriggered",
-      handleReceiveCustomAppWebhook
+      handleReceiveCustomAppWebhook,
     );
 
     nodemon({
@@ -107,7 +110,9 @@ dev
       } else if (data.code === "h") {
         terminal("\n");
         terminal("  press d to deploy\n");
-        terminal(`  press l to turn DEBUG logs ${logDisplayLevel === "DEBUG" ? "off" : "on"}\n`);
+        terminal(
+          `  press l to turn DEBUG logs ${logDisplayLevel === "DEBUG" ? "off" : "on"}\n`,
+        );
         terminal("  press q to quit\n");
         terminal("\n");
       } else {

--- a/packages/@runlightyear/cli/src/commands/dev/index.ts
+++ b/packages/@runlightyear/cli/src/commands/dev/index.ts
@@ -22,7 +22,7 @@ export const dev = new Command("dev");
 
 dev
   .description(
-    "Automatically deploy changes, run actions, and respond to webhooks in your dev environment",
+    "Automatically deploy changes, run actions, and respond to webhooks in your dev environment"
   )
   .addOption(new Option("--dev").hideHelp())
   .action(async () => {
@@ -40,10 +40,10 @@ dev
     const pusher = await getPusher(credentials);
 
     console.debug(
-      `Attempting to subscribe to presence channel ${credentials.devEnvId}\n`,
+      `Attempting to subscribe to presence channel ${credentials.devEnvId}\n`
     );
     const presenceSubscription = pusher.subscribe(
-      `presence-${credentials.devEnvId}`,
+      `presence-${credentials.devEnvId}`
     );
     presenceSubscription.bind("pusher:subscription_succeeded", () => {
       console.debug("Subscribed to presence channel\n");
@@ -51,7 +51,7 @@ dev
 
     console.debug(
       "Attempting to subscribe to regular channel",
-      credentials.devEnvId,
+      credentials.devEnvId
     );
     const subscription = pusher.subscribe(credentials.devEnvId);
     subscription.bind("pusher:subscription_succeeded", () => {
@@ -62,23 +62,23 @@ dev
     subscription.bind("localResubscribeTriggered", handleResubscribe);
     subscription.bind(
       "localGetAuthRequestUrlTriggered",
-      handleGetAuthRequestUrl,
+      handleGetAuthRequestUrl
     );
     subscription.bind(
       "localRequestAccessTokenTriggered",
-      handleRequestAccessToken,
+      handleRequestAccessToken
     );
     subscription.bind(
       "localRefreshAccessTokenTriggered",
-      handleRefreshAccessToken,
+      handleRefreshAccessToken
     );
     subscription.bind(
       "localRefreshSubscriptionTriggered",
-      handleRefreshSubscription,
+      handleRefreshSubscription
     );
     subscription.bind(
       "localReceiveCustomAppWebhookTriggered",
-      handleReceiveCustomAppWebhook,
+      handleReceiveCustomAppWebhook
     );
 
     nodemon({
@@ -111,7 +111,9 @@ dev
         terminal("\n");
         terminal("  press d to deploy\n");
         terminal(
-          `  press l to turn DEBUG logs ${logDisplayLevel === "DEBUG" ? "off" : "on"}\n`,
+          `  press l to turn DEBUG logs ${
+            logDisplayLevel === "DEBUG" ? "off" : "on"
+          }\n`
         );
         terminal("  press q to quit\n");
         terminal("\n");

--- a/packages/@runlightyear/cli/src/commands/dev/index.ts
+++ b/packages/@runlightyear/cli/src/commands/dev/index.ts
@@ -107,7 +107,7 @@ dev
       } else if (data.code === "h") {
         terminal("\n");
         terminal("  press d to deploy\n");
-        terminal("  press l to toggle DEBUG logs on/off\n");
+        terminal(`  press l to turn DEBUG logs ${logDisplayLevel === "DEBUG" ? "off" : "on"}\n`);
         terminal("  press q to quit\n");
         terminal("\n");
       } else {

--- a/packages/@runlightyear/cli/src/commands/dev/index.ts
+++ b/packages/@runlightyear/cli/src/commands/dev/index.ts
@@ -4,7 +4,7 @@ import getPusherCredentials from "../../shared/getPusherCredentials";
 import handleRunLocal from "./handleRunLocal";
 import nodemon from "nodemon";
 import { terminal } from "terminal-kit";
-import { setLogDisplayLevel } from "../../shared/setLogDisplayLevel";
+import { setLogDisplayLevel, logDisplayLevel } from "../../shared/setLogDisplayLevel";
 import { prepareConsole } from "../../logging";
 import handleResubscribe from "./handleResubscribe";
 import { largeLogo } from "../../largeLogo";
@@ -96,18 +96,18 @@ dev
       } else if (data.code === "d") {
         pushOperation({ operation: "deploy", params: undefined });
       } else if (data.code === "l") {
-        console.info("DEBUG logging on");
-        setLogDisplayLevel("DEBUG");
-        prepareConsole();
-      } else if (data.code === "m") {
-        console.info("DEBUG logging off");
-        setLogDisplayLevel("INFO");
+        if (logDisplayLevel === "DEBUG") {
+          console.info("DEBUG logging off");
+          setLogDisplayLevel("INFO");
+        } else {
+          console.info("DEBUG logging on");
+          setLogDisplayLevel("DEBUG");
+        }
         prepareConsole();
       } else if (data.code === "h") {
         terminal("\n");
         terminal("  press d to deploy\n");
-        terminal("  press l to turn DEBUG logs on\n");
-        terminal("  press m to turn DEBUG logs off\n");
+        terminal("  press l to toggle DEBUG logs on/off\n");
         terminal("  press q to quit\n");
         terminal("\n");
       } else {


### PR DESCRIPTION
The CLI's dev mode was updated to allow toggling debug logs with a single key.

In `packages/@runlightyear/cli/src/commands/dev/index.ts`:
*   The `logDisplayLevel` was imported from `setLogDisplayLevel` to enable checking the current log state.
*   The handler for the 'l' key was modified:
    *   It now checks the current `logDisplayLevel`.
    *   If the level is "DEBUG", it's set to "INFO" (turning logs off).
    *   Otherwise, it's set to "DEBUG" (turning logs on).
*   The previous 'm' key handler, which explicitly turned logs off, was removed.
*   The help message displayed by the 'h' key was updated to reflect "press l to toggle DEBUG logs on/off", replacing the separate 'l' and 'm' key instructions.

This change streamlines the debug log control by consolidating the on/off functionality into a single toggle key.