### PR TITLE
Create security update for http-proxy-middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   },
   "pnpm": {
     "overrides": {
-      "path-to-regexp@<0.1.12": "0.1.12"
+      "path-to-regexp@<0.1.12": "0.1.12",
+      "http-proxy-middleware@<2.0.7": "2.0.7"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   path-to-regexp@<0.1.12: 0.1.12
+  http-proxy-middleware@<2.0.7: 2.0.7
 
 importers:
 
@@ -9357,8 +9358,8 @@ packages:
     resolution: {integrity: sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==}
     dev: false
 
-  /http-proxy-middleware@2.0.6(@types/express@4.17.21):
-    resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
+  /http-proxy-middleware@2.0.7(@types/express@4.17.21):
+    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -14483,7 +14484,7 @@ packages:
       express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
-      http-proxy-middleware: 2.0.6(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.7(@types/express@4.17.21)
       ipaddr.js: 2.2.0
       launch-editor: 2.8.0
       open: 8.4.2


### PR DESCRIPTION
Upgrade `http-proxy-middleware` to version 2.0.7 to fix a Denial of Service vulnerability (CVE-2024-21536).