### PR TITLE
Fix http-proxy-middleware vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "pnpm": {
     "overrides": {
       "path-to-regexp@<0.1.12": "0.1.12",
-      "http-proxy-middleware@<2.0.7": "2.0.7"
+      "http-proxy-middleware@<2.0.9": "2.0.9"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   path-to-regexp@<0.1.12: 0.1.12
-  http-proxy-middleware@<2.0.7: 2.0.7
+  http-proxy-middleware@<2.0.9: 2.0.9
 
 importers:
 
@@ -9369,8 +9369,8 @@ packages:
     resolution: {integrity: sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==}
     dev: false
 
-  /http-proxy-middleware@2.0.7(@types/express@4.17.21):
-    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
+  /http-proxy-middleware@2.0.9(@types/express@4.17.21):
+    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -14534,7 +14534,7 @@ packages:
       express: 4.19.2
       graceful-fs: 4.2.11
       html-entities: 2.5.2
-      http-proxy-middleware: 2.0.7(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
       ipaddr.js: 2.2.0
       launch-editor: 2.8.0
       open: 8.4.2


### PR DESCRIPTION
Update `http-proxy-middleware` to version 2.0.9 to resolve the `writeBody` double-call vulnerability (CVE-2025-32996).

The previous `pnpm.overrides` entry was preventing the update to a patched version, which has now been adjusted.