### PR TITLE
Update prismjs to fix vulnerability

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -22,7 +22,7 @@
     "@docusaurus/preset-classic": "3.8.1",
     "@mdx-js/react": "^3.1.0",
     "clsx": "^2.1.0",
-    "prism-react-renderer": "^1.3.5",
+    "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "typedoc-plugin-missing-exports": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "pnpm": {
     "overrides": {
       "path-to-regexp@<0.1.12": "0.1.12",
-      "http-proxy-middleware@<2.0.7": "2.0.7"
+      "http-proxy-middleware@<2.0.7": "2.0.7",
+      "prismjs": "^1.30.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   path-to-regexp@<0.1.12: 0.1.12
   http-proxy-middleware@<2.0.7: 2.0.7
+  prismjs: ^1.30.0
 
 importers:
 
@@ -68,8 +69,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.1
       prism-react-renderer:
-        specifier: ^1.3.5
-        version: 1.3.5(react@18.3.1)
+        specifier: ^2.4.1
+        version: 2.4.1(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -4429,7 +4430,7 @@ packages:
       nprogress: 0.2.0
       postcss: 8.5.6
       prism-react-renderer: 2.4.1(react@18.3.1)
-      prismjs: 1.29.0
+      prismjs: 1.30.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router-dom: 5.3.4(react@18.3.1)
@@ -12288,14 +12289,6 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /prism-react-renderer@1.3.5(react@18.3.1):
-    resolution: {integrity: sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==}
-    peerDependencies:
-      react: '>=0.14.9'
-    dependencies:
-      react: 18.3.1
-    dev: false
-
   /prism-react-renderer@2.4.1(react@18.3.1):
     resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
     peerDependencies:
@@ -12306,8 +12299,8 @@ packages:
       react: 18.3.1
     dev: false
 
-  /prismjs@1.29.0:
-    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
+  /prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
     dev: false
 


### PR DESCRIPTION
Resolve PrismJS DOM Clobbering vulnerability (CVE-2024-53382) by updating dependencies and adding a pnpm override.

The vulnerability persisted even after updating `prism-react-renderer` because `@docusaurus/theme-classic` directly depends on a vulnerable version of PrismJS (1.29.0). A pnpm override was implemented to force all packages to use the patched PrismJS 1.30.0, as Docusaurus itself bundles the vulnerable version.