### PR TITLE
Upgrade path-to-regexp for security patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "pnpm": {
     "overrides": {
       "path-to-regexp@<0.1.12": "0.1.12",
+      "path-to-regexp@>=0.2.0 <1.9.0": "1.9.0",
       "http-proxy-middleware@<2.0.9": "2.0.9",
       "body-parser@<1.20.3": "1.20.3"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   path-to-regexp@<0.1.12: 0.1.12
+  path-to-regexp@>=0.2.0 <1.9.0: 1.9.0
   http-proxy-middleware@<2.0.9: 2.0.9
   body-parser@<1.20.3: 1.20.3
 
@@ -11603,8 +11604,8 @@ packages:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
     dev: false
 
-  /path-to-regexp@1.8.0:
-    resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
+  /path-to-regexp@1.9.0:
+    resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
     dependencies:
       isarray: 0.0.1
     dev: false
@@ -12754,7 +12755,7 @@ packages:
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
-      path-to-regexp: 1.8.0
+      path-to-regexp: 1.9.0
       prop-types: 15.8.1
       react: 18.3.1
       react-is: 16.13.1


### PR DESCRIPTION
Upgrade `path-to-regexp` to 1.9.0 via pnpm override to fix a ReDoS vulnerability.

This addresses CVE-2024-45296, a ReDoS vulnerability in `path-to-regexp` versions between 0.2.0 and 1.9.0. The project was using `path-to-regexp@1.8.0` (via `react-router@5.3.4`), which is now forced to 1.9.0.