### PR TITLE
Enforce app or custom app for integrations

### DIFF
--- a/packages/@runlightyear/lightyear/src/base/integration.ts
+++ b/packages/@runlightyear/lightyear/src/base/integration.ts
@@ -33,12 +33,16 @@ interface IntegrationWithCustomApp extends BaseIntegrationProps {
 /**
  * @alpha
  */
-export type DefineIntegrationProps = IntegrationWithApp | IntegrationWithCustomApp;
+export type DefineIntegrationProps =
+  | IntegrationWithApp
+  | IntegrationWithCustomApp;
 
 /**
  * @alpha
  */
-export type DeployIntegrationProps = IntegrationWithApp | IntegrationWithCustomApp;
+export type DeployIntegrationProps =
+  | IntegrationWithApp
+  | IntegrationWithCustomApp;
 
 /**
  * @alpha

--- a/packages/@runlightyear/lightyear/src/base/integration.ts
+++ b/packages/@runlightyear/lightyear/src/base/integration.ts
@@ -1,30 +1,44 @@
 import { pushToDeployList } from "./deploy";
 
 /**
+ * Base properties for integration definitions
  * @alpha
  */
-export interface DefineIntegrationProps {
+interface BaseIntegrationProps {
   name: string;
   title: string;
   description?: string;
-  app?: string;
-  customApp?: string;
   actions?: Array<string>;
   webhooks?: Array<string>;
 }
 
 /**
+ * Integration with a system app
  * @alpha
  */
-export interface DeployIntegrationProps {
-  name: string;
-  title: string;
-  description?: string;
-  app?: string;
-  customApp?: string;
-  actions?: Array<string>;
-  webhooks?: Array<string>;
+interface IntegrationWithApp extends BaseIntegrationProps {
+  app: string;
+  customApp?: never;
 }
+
+/**
+ * Integration with a custom app
+ * @alpha
+ */
+interface IntegrationWithCustomApp extends BaseIntegrationProps {
+  app?: never;
+  customApp: string;
+}
+
+/**
+ * @alpha
+ */
+export type DefineIntegrationProps = IntegrationWithApp | IntegrationWithCustomApp;
+
+/**
+ * @alpha
+ */
+export type DeployIntegrationProps = IntegrationWithApp | IntegrationWithCustomApp;
 
 /**
  * @alpha

--- a/packages/@runlightyear/lightyear/src/base/syncIntegration.ts
+++ b/packages/@runlightyear/lightyear/src/base/syncIntegration.ts
@@ -2,7 +2,7 @@ import { AppName } from "./action";
 import { AuthData } from "./auth";
 import { SyncConnector } from "../connectors/SyncConnector";
 import { defineIntegration } from "./integration";
-import { defineSyncAction } from "./syncAction";
+import { defineSyncAction, SyncActionWithApp, SyncActionWithCustomApp } from "./syncAction";
 
 export interface ConnectorProps {
   auth: AuthData;
@@ -18,17 +18,39 @@ export interface FrequencyProps {
   hardDelete?: number;
 }
 
-export interface DefineSyncIntegrationProps {
+/**
+ * Base properties for sync integration definitions
+ */
+interface BaseSyncIntegrationProps {
   name: string;
   title: string;
   description?: string;
   connector: typeof SyncConnector | ((props: ConnectorProps) => SyncConnector);
   collection: string;
-  app?: AppName;
-  customApp?: string;
   frequency?: FrequencyProps;
   direction?: "pull" | "push" | "bidirectional";
 }
+
+/**
+ * Sync integration with a system app
+ */
+interface SyncIntegrationWithApp extends BaseSyncIntegrationProps {
+  app: AppName;
+  customApp?: never;
+}
+
+/**
+ * Sync integration with a custom app
+ */
+interface SyncIntegrationWithCustomApp extends BaseSyncIntegrationProps {
+  app?: never;
+  customApp: string;
+}
+
+/**
+ * Type for defining sync integrations - must specify exactly one of app or customApp
+ */
+export type DefineSyncIntegrationProps = SyncIntegrationWithApp | SyncIntegrationWithCustomApp;
 
 function isConnectorClass(
   x: typeof SyncConnector | ((props: ConnectorProps) => SyncConnector)
@@ -43,23 +65,42 @@ function isConnectorFunction(
 }
 
 export function defineSyncIntegration(props: DefineSyncIntegrationProps) {
-  return defineIntegration({
-    name: props.name,
-    title: props.title,
-    description: props.description,
-    app: props.app,
-    customApp: props.customApp,
-    actions: [
-      defineSyncAction({
-        name: `${props.name}_sync`,
-        title: `${props.title} Sync`,
+  // Create the appropriate integration props based on whether app or customApp is provided
+  const integrationProps = 'app' in props && props.app
+    ? {
+        name: props.name,
+        title: props.title,
+        description: props.description,
         app: props.app,
+        actions: [
+          defineSyncAction({
+            name: `${props.name}_sync`,
+            title: `${props.title} Sync`,
+            app: props.app,
+            connector: props.connector,
+            collection: props.collection,
+            frequency: props.frequency,
+            direction: props.direction,
+          } as SyncActionWithApp),
+        ],
+      }
+    : {
+        name: props.name,
+        title: props.title,
+        description: props.description,
         customApp: props.customApp,
-        connector: props.connector,
-        collection: props.collection,
-        frequency: props.frequency,
-        direction: props.direction,
-      }),
-    ],
-  });
+        actions: [
+          defineSyncAction({
+            name: `${props.name}_sync`,
+            title: `${props.title} Sync`,
+            customApp: props.customApp,
+            connector: props.connector,
+            collection: props.collection,
+            frequency: props.frequency,
+            direction: props.direction,
+          } as SyncActionWithCustomApp),
+        ],
+      };
+
+  return defineIntegration(integrationProps);
 }

--- a/packages/@runlightyear/lightyear/src/base/syncIntegration.ts
+++ b/packages/@runlightyear/lightyear/src/base/syncIntegration.ts
@@ -2,7 +2,11 @@ import { AppName } from "./action";
 import { AuthData } from "./auth";
 import { SyncConnector } from "../connectors/SyncConnector";
 import { defineIntegration } from "./integration";
-import { defineSyncAction, SyncActionWithApp, SyncActionWithCustomApp } from "./syncAction";
+import {
+  defineSyncAction,
+  SyncActionWithApp,
+  SyncActionWithCustomApp,
+} from "./syncAction";
 
 export interface ConnectorProps {
   auth: AuthData;
@@ -50,7 +54,9 @@ interface SyncIntegrationWithCustomApp extends BaseSyncIntegrationProps {
 /**
  * Type for defining sync integrations - must specify exactly one of app or customApp
  */
-export type DefineSyncIntegrationProps = SyncIntegrationWithApp | SyncIntegrationWithCustomApp;
+export type DefineSyncIntegrationProps =
+  | SyncIntegrationWithApp
+  | SyncIntegrationWithCustomApp;
 
 function isConnectorClass(
   x: typeof SyncConnector | ((props: ConnectorProps) => SyncConnector)
@@ -66,41 +72,42 @@ function isConnectorFunction(
 
 export function defineSyncIntegration(props: DefineSyncIntegrationProps) {
   // Create the appropriate integration props based on whether app or customApp is provided
-  const integrationProps = 'app' in props && props.app
-    ? {
-        name: props.name,
-        title: props.title,
-        description: props.description,
-        app: props.app,
-        actions: [
-          defineSyncAction({
-            name: `${props.name}_sync`,
-            title: `${props.title} Sync`,
-            app: props.app,
-            connector: props.connector,
-            collection: props.collection,
-            frequency: props.frequency,
-            direction: props.direction,
-          } as SyncActionWithApp),
-        ],
-      }
-    : {
-        name: props.name,
-        title: props.title,
-        description: props.description,
-        customApp: props.customApp,
-        actions: [
-          defineSyncAction({
-            name: `${props.name}_sync`,
-            title: `${props.title} Sync`,
-            customApp: props.customApp,
-            connector: props.connector,
-            collection: props.collection,
-            frequency: props.frequency,
-            direction: props.direction,
-          } as SyncActionWithCustomApp),
-        ],
-      };
+  const integrationProps =
+    "app" in props && props.app
+      ? {
+          name: props.name,
+          title: props.title,
+          description: props.description,
+          app: props.app,
+          actions: [
+            defineSyncAction({
+              name: `${props.name}_sync`,
+              title: `${props.title} Sync`,
+              app: props.app,
+              connector: props.connector,
+              collection: props.collection,
+              frequency: props.frequency,
+              direction: props.direction,
+            } as SyncActionWithApp),
+          ],
+        }
+      : {
+          name: props.name,
+          title: props.title,
+          description: props.description,
+          customApp: props.customApp,
+          actions: [
+            defineSyncAction({
+              name: `${props.name}_sync`,
+              title: `${props.title} Sync`,
+              customApp: props.customApp,
+              connector: props.connector,
+              collection: props.collection,
+              frequency: props.frequency,
+              direction: props.direction,
+            } as SyncActionWithCustomApp),
+          ],
+        };
 
   return defineIntegration(integrationProps);
 }


### PR DESCRIPTION
Enforce compile-time validation for `app` or `customApp` in integration definitions.

Previously, the requirement to specify exactly one of `app` or `customApp` was only enforced at runtime. This PR introduces TypeScript discriminated unions to ensure this constraint is checked at compile time, improving developer experience and preventing potential runtime errors.

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-da7045f5-6df2-45dc-acd7-dda94d1fe8c8) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-da7045f5-6df2-45dc-acd7-dda94d1fe8c8)