### PR TITLE
Add warning when SDK has nothing to deploy

### DIFF
--- a/packages/@runlightyear/lightyear/src/base/deploy.ts
+++ b/packages/@runlightyear/lightyear/src/base/deploy.ts
@@ -72,6 +72,11 @@ export function pushToDeployList(item: DeployItem) {
 export async function deploy({ envName }: Props) {
   console.debug("deployList", JSON.stringify(globalThis.deployList, null, 2));
 
+  if (!globalThis.deployList || globalThis.deployList.length === 0) {
+    console.warn("Warning: No actions, webhooks, integrations, or custom apps found to deploy.");
+    return;
+  }
+
   const names = globalThis.deployList.map((item) => {
     if (item.type === "customApp") {
       return item.customAppProps?.name;


### PR DESCRIPTION
## Summary
- Added a check in the `deploy()` function to handle empty or undefined `deployList`
- Display a warning message instead of throwing an error when there's nothing to deploy
- Function returns early without attempting to process empty deployments

## Test plan
- [ ] Create an empty Lightyear project with no defined actions, webhooks, integrations, or custom apps
- [ ] Run `lightyear deploy prod` (or any environment)
- [ ] Verify that a warning message is displayed: "Warning: No actions, webhooks, integrations, or custom apps found to deploy."
- [ ] Verify that the deployment completes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)