### PR TITLE
Add SyncObject type and update ModelConnector and SyncConnector to ut…

### DIFF
--- a/packages/@runlightyear/sdk/src/builders/index.ts
+++ b/packages/@runlightyear/sdk/src/builders/index.ts
@@ -59,6 +59,7 @@ export type {
   UpdateConfig,
   DeleteConfig,
   BulkConfig,
+  SyncObject,
 } from "./syncConnector";
 
 // Typed sync helpers

--- a/packages/@runlightyear/sdk/src/builders/modelConnector.ts
+++ b/packages/@runlightyear/sdk/src/builders/modelConnector.ts
@@ -9,6 +9,7 @@ import type {
   BulkConfig,
   ListParams,
   ModelConnector as ModelConnectorInterface,
+  SyncObject,
 } from "./syncConnector";
 
 /**
@@ -77,16 +78,16 @@ export class ModelConnectorBuilder<T = any> {
         });
 
         let data = response.data;
-        let items: any[] = [];
+        let items: Array<SyncObject<T>> = [];
 
         if (this.config.list!.responseSchema) {
           data = this.config.list!.responseSchema.parse(data);
         }
 
         if (this.config.list!.transform) {
-          items = (this.config.list as any).transform(data);
+          items = this.config.list!.transform(data);
         } else {
-          items = data as any[];
+          items = data as Array<SyncObject<T>>;
         }
 
         const pg = this.config.list!.pagination as


### PR DESCRIPTION
…ilize it

- Introduced a new SyncObject type to standardize the structure of sync-ready objects.
- Updated ModelConnectorBuilder and SyncConnector classes to use SyncObject for item transformations and responses.
- Enhanced type definitions in ListConfig and related interfaces to improve clarity and maintainability.