### PR TITLE
Implement filtering functionality in ModelConnector and SyncConnector

### DIFF
--- a/packages/@runlightyear/sdk/src/builders/modelConnector.ts
+++ b/packages/@runlightyear/sdk/src/builders/modelConnector.ts
@@ -90,6 +90,17 @@ export class ModelConnectorBuilder<T = any> {
           items = data as Array<SyncObject<T>>;
         }
 
+        if (this.config.list!.filter) {
+          items = items.filter((obj) =>
+            this.config.list!.filter!({
+              obj,
+              lastExternalId: _params.lastExternalId,
+              lastExternalUpdatedAt: _params.lastExternalUpdatedAt,
+              syncType: _params.syncType,
+            })
+          );
+        }
+
         const pg = this.config.list!.pagination as
           | ((args: {
               response: any;
@@ -97,6 +108,8 @@ export class ModelConnectorBuilder<T = any> {
               page?: number;
               offset?: number;
               limit?: number;
+              lastExternalId?: string;
+              lastExternalUpdatedAt?: string;
               syncType: "FULL" | "INCREMENTAL";
             }) => {
               cursor?: string | null;
@@ -113,6 +126,8 @@ export class ModelConnectorBuilder<T = any> {
                 page: _params.page,
                 offset: _params.offset,
                 limit: _params.limit,
+                lastExternalId: _params.lastExternalId,
+                lastExternalUpdatedAt: _params.lastExternalUpdatedAt,
                 syncType: _params.syncType,
               })
             : undefined;


### PR DESCRIPTION
- Added support for filtering list items based on a provided filter function in both ModelConnectorBuilder and SyncConnectorBuilder.
- Updated ListParams and related interfaces to include lastExternalId and lastExternalUpdatedAt for enhanced filtering capabilities.
- Introduced a new ListFilterArgs interface to standardize the arguments passed to filter functions.
- Enhanced unit tests to verify the filtering behavior when a filter function is applied.